### PR TITLE
feat/signout 💥 <userInfo> 전역상태 에러처리 임시완료--- 로그인 회원가입 로직은 구현이 완료되었습니다. 갓우혁💥  

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ const App = () => {
   return (
     <>
       <QueryClientProvider client={queryClient}>
-        <AuthListener />;
+        <AuthListener />
         <Router />
       </QueryClientProvider>
     </>

--- a/src/components/auth/AuthListener.jsx
+++ b/src/components/auth/AuthListener.jsx
@@ -1,18 +1,18 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { supabase } from '../../libs/api/supabaseClient';
 import useAuthStore from '../../stores/useAuthstore';
 import useGetUserInfo from '../../libs/hooks/useGetUserInfo';
 
 const AuthListener = () => {
   const setUserInfo = useAuthStore((state) => state.setUserInfo);
-  const logout = useAuthStore((state) => state.logout);
   const { data: userData, isPending, Error } = useGetUserInfo();
 
+  // 초기 렌더링 시 userInfo 전역상태 세팅
   useEffect(() => {
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (_, session) => {
-      if (session) {
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (session && event === 'INITIAL_SESSION') {
         const userInfo = {
           id: session.user.id,
           email: session.user.email,
@@ -21,8 +21,6 @@ const AuthListener = () => {
         };
 
         setUserInfo(userInfo);
-      } else {
-        logout();
       }
     });
     // cleanUp
@@ -31,8 +29,8 @@ const AuthListener = () => {
     };
   }, [userData]); // userData 변경 시 리렌더링
 
-  if (isPending) return <>pending...</>;
-  if (Error) return <>error...</>;
+  if (isPending) return;
+  if (Error) return;
 
   return <></>;
 };

--- a/src/components/auth/AuthListener.jsx
+++ b/src/components/auth/AuthListener.jsx
@@ -1,33 +1,65 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { supabase } from '../../libs/api/supabaseClient';
 import useAuthStore from '../../stores/useAuthstore';
 import useGetUserInfo from '../../libs/hooks/useGetUserInfo';
 
-const AuthListener = () => {
-  const setUserInfo = useAuthStore((state) => state.setUserInfo);
-  const { data: userData, isPending, Error } = useGetUserInfo();
+const useAuthStateChange = (callback) => {
+  const currentSession = useRef(null);
 
-  // 초기 렌더링 시 userInfo 전역상태 세팅
   useEffect(() => {
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
-      if (session && event === 'INITIAL_SESSION') {
-        const userInfo = {
-          id: session.user.id,
-          email: session.user.email,
-          nickname: userData?.nickname || '',
-          profile_img_url: userData?.profile_img_url || '',
-        };
-
-        setUserInfo(userInfo);
-      }
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (session?.user?.id === currentSession.current?.user?.id) return;
+      currentSession.current = session;
+      callback(event, session);
     });
-    // cleanUp
+
     return () => {
       subscription.unsubscribe();
     };
-  }, [userData]); // userData 변경 시 리렌더링
+  }, []);
+};
+
+const AuthListener = () => {
+  const setUserInfo = useAuthStore((state) => state.setUserInfo);
+  const logout = useAuthStore((state) => state.logout);
+  const { data: userData, isPending, Error } = useGetUserInfo();
+  const [flag, setFlag] = useState(false);
+
+  useAuthStateChange((event, session) => {
+    // if (event === 'SIGNED_IN') {
+    // 로그인 시 처리 로직
+    console.log(event);
+    if (event === 'SIGNED_IN') {
+      const userInfo = {
+        id: session.user.id,
+        email: session.user.email,
+        nickname: userData?.nickname || '',
+        profile_img_url: userData?.profile_img_url || '',
+      };
+
+      setUserInfo(userInfo);
+    } else if (event === 'SIGNED_OUT') {
+      logout();
+    }
+  });
+
+  useEffect(() => {
+    if (!userData) {
+      return;
+    }
+    if (flag) {
+      return;
+    }
+    const userInfo = {
+      nickname: userData?.nickname || '',
+      profile_img_url: userData?.profile_img_url || '',
+    };
+
+    setUserInfo(userInfo);
+    setFlag(true);
+  }, [userData]);
 
   if (isPending) return;
   if (Error) return;

--- a/src/components/auth/AuthListener.jsx
+++ b/src/components/auth/AuthListener.jsx
@@ -1,18 +1,25 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { supabase } from '../../libs/api/supabaseClient';
 import useAuthStore from '../../stores/useAuthstore';
-import useGetUserInfo from '../../libs/hooks/useGetUserInfo';
+import { useAuthMutate } from '../../libs/hooks/useAuth.api';
 
 const useAuthStateChange = (callback) => {
   const currentSession = useRef(null);
+  const { loginUserInfo } = useAuthMutate();
 
   useEffect(() => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
+      console.log('첫번째 유즈 이펙트.=====>', event, session);
       if (session?.user?.id === currentSession.current?.user?.id) return;
       currentSession.current = session;
       callback(event, session);
+
+      if (session) {
+        const id = session.user.id;
+        loginUserInfo({ id });
+      }
     });
 
     return () => {
@@ -22,47 +29,13 @@ const useAuthStateChange = (callback) => {
 };
 
 const AuthListener = () => {
-  const setUserInfo = useAuthStore((state) => state.setUserInfo);
   const logout = useAuthStore((state) => state.logout);
-  const { data: userData, isPending, Error } = useGetUserInfo();
-  const [flag, setFlag] = useState(false);
 
   useAuthStateChange((event, session) => {
-    // if (event === 'SIGNED_IN') {
-    // 로그인 시 처리 로직
-    console.log(event);
-    if (event === 'SIGNED_IN') {
-      const userInfo = {
-        id: session.user.id,
-        email: session.user.email,
-        nickname: userData?.nickname || '',
-        profile_img_url: userData?.profile_img_url || '',
-      };
-
-      setUserInfo(userInfo);
-    } else if (event === 'SIGNED_OUT') {
+    if (event === 'SIGNED_OUT') {
       logout();
     }
   });
-
-  useEffect(() => {
-    if (!userData) {
-      return;
-    }
-    if (flag) {
-      return;
-    }
-    const userInfo = {
-      nickname: userData?.nickname || '',
-      profile_img_url: userData?.profile_img_url || '',
-    };
-
-    setUserInfo(userInfo);
-    setFlag(true);
-  }, [userData]);
-
-  if (isPending) return;
-  if (Error) return;
 
   return <></>;
 };

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,9 +1,21 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import useAuthStore from '../../stores/useAuthstore';
+import { supabase } from '../../libs/api/supabaseClient';
+import { ROUTES } from '../../constants/routes';
 
 const Header = () => {
   const { isLogin } = useAuthStore();
-  const logout = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
+
+  const handleAuthAction = async () => {
+    if (isLogin) {
+      await supabase.auth.signOut();
+      alert('로그아웃 되었습니다.');
+      navigate(ROUTES.HOME);
+    } else {
+      navigate(ROUTES.SIGNIN);
+    }
+  };
 
   return (
     <header className="fixed h-28 w-full">
@@ -11,16 +23,10 @@ const Header = () => {
         <h1 className="flex-grow">
           <Link to="/">로고</Link>
         </h1>
-        {isLogin ? (
-          <div className="flex gap-5">
-            <Link to="/mypage">마이페이지</Link>
-            <button onClick={logout} className="cursor-pointer">
-              로그아웃
-            </button>
-          </div>
-        ) : (
-          <Link to="/signin">로그인</Link>
-        )}
+        <div className="flex gap-5">
+          {isLogin && <Link to={ROUTES.MYPAGE}>마이페이지</Link>}
+          <button onClick={handleAuthAction}>{isLogin ? '로그아웃' : '로그인'}</button>
+        </div>
       </nav>
     </header>
   );

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,6 @@
+// constants/routes.js
+export const ROUTES = {
+  MYPAGE: '/mypage',
+  SIGNIN: '/signin',
+  HOME: '/',
+};

--- a/src/libs/hooks/useAuth.api.js
+++ b/src/libs/hooks/useAuth.api.js
@@ -1,0 +1,43 @@
+import { useMutation } from '@tanstack/react-query';
+import { supabase } from '../api/supabaseClient';
+import useAuthStore from '../../stores/useAuthstore';
+
+export const useAuthMutate = () => {
+  const setUserInfo = useAuthStore((state) => state.setUserInfo);
+
+  const { mutate: signUp } = useMutation({
+    mutationFn: async ({ email, password }) => {
+      const { data } = await supabase.auth.signUp({ email, password });
+      return data;
+    },
+  });
+
+  const { mutate: loginUserInfo } = useMutation({
+    mutationFn: async ({ id }) => {
+      const { data } = await supabase.from('users').select('*').eq('id', id).single();
+      return data;
+    },
+    onSuccess: (data) => {
+      const { id, email, nickname, profile_img_url } = data;
+      setUserInfo({ id, email, nickname, profile_img_url });
+    },
+  });
+
+  const { mutate: updateUserInfo } = useMutation({
+    mutationFn: async ({ nickname, email }) => {
+      const { data } = await supabase
+        .from('users')
+        .update({ nickname })
+        .eq('email', email)
+        .select()
+        .single();
+      return data;
+    },
+    onSuccess: (data) => {
+      const { id, nickname, email } = data;
+      setUserInfo({ id, email, nickname });
+    },
+  });
+
+  return { signUp, updateUserInfo, loginUserInfo };
+};

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -1,72 +1,41 @@
 import { useEffect, useRef, useState } from 'react';
 import { supabase } from '../libs/api/supabaseClient';
+import useAuthStore from '../stores/useAuthstore';
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
+const DEFAULT_IMAGE = '/public/user2.png';
+
 const Mypage = () => {
-  // 폼 상태 관리
+  const { userInfo, setUserInfo } = useAuthStore();
+  const fileInputRef = useRef(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 폼 상태
   const [formData, setFormData] = useState({
-    myNickname: '',
     newNickname: '',
-    userId: '',
     imagePreview: '',
     file: null,
     oldFilePath: '',
   });
 
-  // 제출 중 상태
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  // 파일 입력 필드 접근을 위한 ref
-  const fileInputRef = useRef(null);
-
-  // 유저 아이디 가져오기
+  // userInfo 변경 시 상태 초기화
   useEffect(() => {
-    const fetchUser = async () => {
-      const { data, error } = await supabase.auth.getUser();
-      if (error) {
-        console.error('사용자 정보를 가져오는 데 실패:', error.message);
-        return;
-      }
-      setFormData((prev) => ({ ...prev, userId: data.user?.id }));
-    };
-    fetchUser();
-  }, []);
+    if (userInfo !== null) {
+      setFormData({
+        newNickname: userInfo.nickname,
+        imagePreview: userInfo.profile_img_url || DEFAULT_IMAGE,
+        file: null,
+        oldFilePath: userInfo.profile_img_url ?? null,
+      });
+    }
+  }, [userInfo]);
 
-  useEffect(() => {
-    // userId가 없으면 실행하지 않음
-    if (!formData.userId) return;
-
-    // 유저 정보 가져오기
-    const fetchUserData = async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('*')
-        .eq('id', formData.userId)
-        .single();
-
-      if (error) {
-        console.error('데이터 로드 실패:', error);
-        return;
-      }
-
-      setFormData((prev) => ({
-        ...prev,
-        imagePreview: data.profile_img_url,
-        myNickname: data.nickname,
-        oldFilePath: data.profile_img_url,
-      }));
-    };
-
-    fetchUserData();
-  }, [formData.userId]);
-
-  // 입력 필드 핸들러
+  // 입력 핸들러
   const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, newNickname: e.target.value }));
   };
 
-  // 이미지 파일 변경 핸들러 수정
+  // 파일 선택 핸들러
   const handleFileChange = (e) => {
     const selectedFile = e.target.files[0];
     if (!selectedFile) return;
@@ -76,31 +45,30 @@ const Mypage = () => {
       return;
     }
 
-    setFormData((prev) => ({ ...prev, file: selectedFile }));
-
-    if (selectedFile.type.startsWith('image/')) {
-      const fileURL = URL.createObjectURL(selectedFile);
-      setFormData((prev) => ({ ...prev, imagePreview: fileURL }));
-    }
+    setFormData((prev) => ({
+      ...prev,
+      file: selectedFile,
+      imagePreview: URL.createObjectURL(selectedFile),
+    }));
   };
 
   // 이미지 제거 핸들러
   const handleRemoveImage = (e) => {
     e.preventDefault();
-    setFormData((prev) => ({ ...prev, file: null, imagePreview: '' }));
+    resetFileInput();
+    setFormData((prev) => ({ ...prev, file: null, imagePreview: DEFAULT_IMAGE }));
+  };
+
+  // 파일 입력 필드 초기화
+  const resetFileInput = () => {
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  // 이미지 URL 메모리 해제
-  useEffect(() => {
-    return () => {
-      if (formData.imagePreview) URL.revokeObjectURL(formData.imagePreview);
-    };
-  }, [formData.imagePreview]);
-
-  // 기존 이미지 제거 핸들러
+  // 기존 이미지 삭제
   const removeOldImage = async (oldFilePath) => {
+    if (!oldFilePath) return true;
     const oldFileName = oldFilePath.split('uploads/')[1];
+
     const { error } = await supabase.storage
       .from('profile-images')
       .remove([`public/uploads/${oldFileName}`]);
@@ -112,10 +80,11 @@ const Mypage = () => {
     return true;
   };
 
-  // 새로운 이미지 업로드
+  // 새 이미지 업로드
   const uploadNewImage = async (file) => {
     const fileExtension = file.name.split('.').pop();
     const filePath = `uploads/${Date.now()}.${fileExtension}`;
+
     const { error } = await supabase.storage
       .from('profile-images')
       .upload(`public/${filePath}`, file);
@@ -124,73 +93,53 @@ const Mypage = () => {
       console.error('이미지 업로드 실패:', error.message);
       return null;
     }
+
     return `${
       import.meta.env.VITE_SUPABASE_URL
     }/storage/v1/object/public/profile-images/public/${filePath}`;
   };
 
-  // 업데이트 버튼 클릭시 이벤트
+  // 프로필 업데이트
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    // 제출 중이면 return
     if (isSubmitting) return;
+
     setIsSubmitting(true);
+    try {
+      const { newNickname, file, oldFilePath } = formData;
+      let fileUrl = oldFilePath;
 
-    const { newNickname, userId, file, oldFilePath } = formData;
-
-    let fileUrl = oldFilePath;
-
-    if (file) {
       // 새 이미지 업로드
-      const uploadedFileUrl = await uploadNewImage(file);
-      if (!uploadedFileUrl) {
-        setIsSubmitting(false);
-        alert('이미지 업로드 실패');
-        return;
+      if (file) {
+        fileUrl = await uploadNewImage(file);
+        if (!fileUrl) throw new Error('이미지 업로드 실패');
+
+        if (oldFilePath && !(await removeOldImage(oldFilePath))) {
+          throw new Error('기존 이미지 삭제 실패');
+        }
       }
 
-      fileUrl = uploadedFileUrl;
-
-      // 기존 이미지 삭제
-      if (oldFilePath && !(await removeOldImage(oldFilePath))) {
-        setIsSubmitting(false);
-        alert('기존 이미지 삭제 실패');
-        return;
+      // 기존 이미지 삭제된 경우
+      if (!file && oldFilePath) {
+        const success = await removeOldImage(oldFilePath);
+        if (!success) throw new Error('기존 이미지 삭제 실패');
+        fileUrl = null;
       }
-    }
 
-    // 파일 삭제된 경우
-    if (file === null && oldFilePath) {
-      const success = await removeOldImage(oldFilePath);
-      if (!success) {
-        setIsSubmitting(false);
-        alert('기존 이미지 삭제 실패');
-        return;
-      }
-      fileUrl = null;
-    }
+      const { error } = await supabase
+        .from('users')
+        .update({ nickname: newNickname, profile_img_url: fileUrl })
+        .eq('id', userInfo.id);
 
-    const { error } = await supabase
-      .from('users')
-      .update({ nickname: newNickname, profile_img_url: fileUrl })
-      .eq('id', userId);
+      if (error) throw new Error('업데이트에 실패했습니다.');
 
-    if (error) {
+      setUserInfo({ nickname: newNickname, profile_img_url: fileUrl });
+      alert('프로필이 성공적으로 업데이트되었습니다!');
+    } catch (error) {
+      alert(error.message);
+    } finally {
       setIsSubmitting(false);
-      alert('업데이트에 실패했습니다. 다시 시도해주세요.');
-      console.error('업데이트 실패:', error.message);
-      return;
     }
-
-    setFormData((prev) => ({
-      ...prev,
-      myNickname: newNickname,
-      oldFilePath: fileUrl,
-    }));
-
-    alert('프로필이 성공적으로 업데이트되었습니다!');
-    setIsSubmitting(false);
   };
 
   return (
@@ -198,6 +147,7 @@ const Mypage = () => {
       <div className="bg-white shadow-lg rounded-lg p-8 max-w-md w-full">
         <h1 className="text-3xl font-bold text-primary-color mb-6">프로필 수정</h1>
         <form className="space-y-6 bg-gray-50 p-6 rounded-lg shadow-md" onSubmit={handleSubmit}>
+          {/* 이미지 업로드 */}
           <div>
             <label htmlFor="inputFile">
               프로필 이미지
@@ -210,43 +160,37 @@ const Mypage = () => {
                 hidden
               />
               <div className="relative inline-block w-full h-60">
-                {formData.imagePreview ? (
-                  <>
-                    <img
-                      src={formData.imagePreview}
-                      alt="이미지 미리보기"
-                      className="w-full h-60 rounded-lg border-2 border-gray-300 object-contain"
-                    />
-                    <button
-                      onClick={handleRemoveImage}
-                      className="absolute top-2 right-2 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center hover:bg-black/70"
-                    >
-                      ×
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <img
-                      src="/public/user2.png"
-                      alt="기본이미지"
-                      className="w-full h-60 object-contain"
-                    />
-                  </>
+                <img
+                  src={formData.imagePreview || DEFAULT_IMAGE}
+                  alt="이미지 미리보기"
+                  className="w-full h-60 rounded-lg border-2 border-gray-300 object-contain"
+                />
+                {formData.imagePreview !== DEFAULT_IMAGE && (
+                  <button
+                    onClick={handleRemoveImage}
+                    className="absolute top-2 right-2 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center hover:bg-black/70"
+                  >
+                    ×
+                  </button>
                 )}
               </div>
             </label>
           </div>
-          <label className="p-2">닉네임 : {formData.myNickname}</label>
+
+          {/* 닉네임 입력 */}
+          <label className="p-2">현재 닉네임: {userInfo.nickname}</label>
           <input
             type="text"
-            name="nickname"
-            value={formData.nickname}
+            name="newNickname"
+            value={formData.newNickname ?? ''}
             onChange={handleInputChange}
             placeholder="닉네임"
             minLength={1}
             required
             className="w-full p-4 border border-gray-300 rounded-lg mt-2"
           />
+
+          {/* 제출 버튼 */}
           <button
             type="submit"
             disabled={isSubmitting}

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -120,7 +120,7 @@ const Mypage = () => {
       }
 
       // 기존 이미지 삭제된 경우
-      if (!file && oldFilePath) {
+      if (!file && formData.imagePreview === DEFAULT_IMAGE) {
         const success = await removeOldImage(oldFilePath);
         if (!success) throw new Error('기존 이미지 삭제 실패');
         fileUrl = null;

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -2,11 +2,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../libs/api/supabaseClient';
 import { useState } from 'react';
 import AuthForm from '../components/auth/AuthForm';
+import { useAuthMutate } from '../libs/hooks/useAuth.api';
 
 const Signup = () => {
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
-
+  const { updateUserInfo } = useAuthMutate();
   const handleSignup = async (formData) => {
     const { email, password, passwordRecheck, nickname } = formData;
 
@@ -39,13 +40,7 @@ const Signup = () => {
 
     // public.users 테이블 내 nickname 저장
     try {
-      // const { error } = await supabase.from('users').upsert({ email, nickname });
-      const { error } = await supabase.from('users').update({ nickname }).eq('email', email);
-
-      if (error) {
-        setErrorMessage(error.message);
-        return;
-      }
+      updateUserInfo({ nickname, email });
       navigate('/signin');
     } catch (error) {
       setErrorMessage('닉네임 저장 중 오류가 발생했습니다.');

--- a/src/stores/useAuthstore.js
+++ b/src/stores/useAuthstore.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import { persist } from 'zustand/middleware';
 
 const initialState = {
   id: '',
@@ -9,24 +10,31 @@ const initialState = {
 };
 
 const useAuthStore = create(
-  immer((set) => {
-    return {
-      isLogin: false,
-      userInfo: initialState,
-      setUserInfo: (userInfo) => {
-        set((state) => {
-          state.userInfo = { ...state.userInfo, ...userInfo };
-          state.isLogin = true;
-        });
-      },
-      logout: () => {
-        set((state) => {
-          state.userInfo = initialState;
-          state.isLogin = false;
-        });
-      },
-    };
-  })
+  // persist -> userinfo localstorage저장
+  persist(
+    immer((set) => {
+      // immer 삭제ㅋ
+      return {
+        isLogin: false, // 새로고침 시 당연히 false -> persist 쓰기
+        userInfo: initialState,
+        setUserInfo: (userInfo) => {
+          set((state) => {
+            state.userInfo = { ...state.userInfo, ...userInfo };
+            state.isLogin = true;
+          });
+        },
+        logout: () => {
+          set((state) => {
+            state.userInfo = initialState;
+            state.isLogin = false;
+          });
+        },
+      };
+    }),
+    {
+      name: 'gachigagae-auth',
+    }
+  )
 );
 
 export default useAuthStore;


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 
#28 

## 📝작업 내용

> 영현님께서 마이페이지 작업하시다가 이슈 공유해주시어 수정 후 배포드립니다.
> 기존 작업 내용이 계속 재렌더링 되는 이슈가 있었는데요, 관련하여 타 페이지에서 설정한 state가 userInfo의 변경에 따라 유지되지 않고 계속 초기화되는 이슈가 있었습니다.
> 동훈 튜터님께서 onAuthStateChange의 event에 따른 예외처리가 필요하다는 의견 주셨고, 해당 내용 반영 수정하였습니다!
> 전역상태 업데이트 내용이다보니, 빠른 검토와 승인을 요청드립니다:)

(추가)
> 로그아웃 로직 구현완료 --- 탠스택 리팩토링 및 userInfo 초기화 로직 구현 중...

## 💬리뷰 요구사항
> 코드 상 이견 없으시면 이대로 진행하다가, 또 전역상태 관련 이슈가 발생할 시 알려주시면 감사하겠습니다! 빠른 문제점 찾아주시고 해결법 공유해주신 갓.영현님께 감사를!
