### PR TITLE
Feat/social login -- 구글 소셜로그인 기능 추가 / 로그아웃 로직 개선

### DIFF
--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -63,7 +63,7 @@ const AuthForm = ({ mode, onSubmit, errorMessage }) => {
       {errorMessage && <p className="text-red-500 mt-2">{errorMessage}</p>}
       <button
         type="submit"
-        className="rounded-full bg-blue-500 px-7 py-3 mt-4 text-lg leading-8 font-semibold text-white shadow-lg shadow-blue-500/50 hover:bg-blue-600"
+        className="rounded-full bg-[var(--color-orange)] px-7 py-3 mt-4 text-lg leading-8 font-semibold text-white shadow-lg shadow-[var(--color-orange)]-500/50 hover:bg-[var(--color-orange-400)]"
       >
         {mode === 'login' ? '로그인' : '회원가입'}
       </button>

--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const AuthForm = ({ mode, onSubmit }) => {
+const AuthForm = ({ mode, onSubmit, errorMessage }) => {
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -60,6 +60,7 @@ const AuthForm = ({ mode, onSubmit }) => {
           />
         </div>
       )}
+      {errorMessage && <p className="text-red-500 mt-2">{errorMessage}</p>}
       <button
         type="submit"
         className="rounded-full bg-blue-500 px-7 py-3 mt-4 text-lg leading-8 font-semibold text-white shadow-lg shadow-blue-500/50 hover:bg-blue-600"

--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -61,13 +61,30 @@ const AuthForm = ({ mode, onSubmit, errorMessage }) => {
         </div>
       )}
       {errorMessage && <p className="text-red-500 mt-2">{errorMessage}</p>}
-      <button
-        type="submit"
-        className="rounded-full bg-[var(--color-orange)] px-7 py-3 mt-4 text-lg leading-8 font-semibold text-white shadow-lg shadow-[var(--color-orange)]-500/50 hover:bg-[var(--color-orange-400)]"
-      >
-        {mode === 'login' ? '로그인' : '회원가입'}
-      </button>
+      <LoginButton type="submit">{mode === 'login' ? '로그인' : '회원가입'}</LoginButton>
     </form>
+  );
+};
+
+export const LoginButton = ({ type, color = 'orange', className, ...props }) => {
+  // 버튼 부수효과 색상 정의
+  const colorVariants = {
+    orange: {
+      hover: 'bg-orange-400',
+      shadow: 'orange-400/50',
+    },
+    grey: {
+      hover: 'bg-gray-600',
+      shadow: 'gray-500/50',
+    },
+  };
+
+  return (
+    <button
+      type={type}
+      className={`rounded-full bg-[var(--color-${color})] px-7 py-3 mt-3 text-lg leading-8 font-semibold text-white shadow-lg shadow-${colorVariants[color].shadow} hover:${colorVariants[color].hover} cursor-pointer ${className}`}
+      {...props}
+    />
   );
 };
 

--- a/src/components/auth/AuthListener.jsx
+++ b/src/components/auth/AuthListener.jsx
@@ -11,7 +11,6 @@ const useAuthStateChange = (callback) => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log('첫번째 유즈 이펙트.=====>', event, session);
       if (session?.user?.id === currentSession.current?.user?.id) return;
       currentSession.current = session;
       callback(event, session);

--- a/src/components/auth/AuthListener.jsx
+++ b/src/components/auth/AuthListener.jsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { supabase } from '../../libs/api/supabaseClient';
-import useAuthStore from '../../stores/useAuthstore';
 import { useAuthMutate } from '../../libs/hooks/useAuth.api';
 
 const useAuthStateChange = (callback) => {
   const currentSession = useRef(null);
-  const { loginUserInfo } = useAuthMutate();
 
+  // 이벤트 필터링: 현재 세션과 새로운 세션의 사용자 ID를 비교하여, 동일한 사용자일 경우 이벤트를 무시
   useEffect(() => {
     const {
       data: { subscription },
@@ -14,11 +13,6 @@ const useAuthStateChange = (callback) => {
       if (session?.user?.id === currentSession.current?.user?.id) return;
       currentSession.current = session;
       callback(event, session);
-
-      if (session) {
-        const id = session.user.id;
-        loginUserInfo({ id });
-      }
     });
 
     return () => {
@@ -28,15 +22,18 @@ const useAuthStateChange = (callback) => {
 };
 
 const AuthListener = () => {
-  const logout = useAuthStore((state) => state.logout);
+  const { loginUserInfo, logoutUser } = useAuthMutate();
 
   useAuthStateChange((event, session) => {
+    if (session) {
+      const id = session.user.id;
+      loginUserInfo({ id });
+    }
     if (event === 'SIGNED_OUT') {
-      logout();
+      logoutUser();
     }
   });
-
-  return <></>;
+  return;
 };
 
 export default AuthListener;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,15 +1,16 @@
 import { Link, useNavigate } from 'react-router-dom';
 import useAuthStore from '../../stores/useAuthstore';
-import { supabase } from '../../libs/api/supabaseClient';
 import { ROUTES } from '../../constants/routes';
+import { useAuthMutate } from '../../libs/hooks/useAuth.api';
 
 const Header = () => {
-  const { isLogin } = useAuthStore();
+  const isLogin = useAuthStore((state) => state.isLogin);
+  const { logoutUser } = useAuthMutate();
   const navigate = useNavigate();
 
   const handleAuthAction = async () => {
     if (isLogin) {
-      await supabase.auth.signOut();
+      logoutUser();
       alert('로그아웃 되었습니다.');
       navigate(ROUTES.HOME);
     } else {

--- a/src/libs/hooks/useAuth.api.js
+++ b/src/libs/hooks/useAuth.api.js
@@ -7,19 +7,14 @@ export const useAuthMutate = () => {
 
   const { mutate: signUp } = useMutation({
     mutationFn: async ({ email, password }) => {
-      const { data } = await supabase.auth.signUp({ email, password });
-      return data;
-    },
-  });
+      const { data, error } = await supabase.auth.signUp({ email, password });
+      console.log('Sign Up Data:', data);
+      console.log('Sign Up Error:', error);
 
-  const { mutate: loginUserInfo } = useMutation({
-    mutationFn: async ({ id }) => {
-      const { data } = await supabase.from('users').select('*').eq('id', id).single();
+      if (error) {
+        throw new Error(error.message);
+      }
       return data;
-    },
-    onSuccess: (data) => {
-      const { id, email, nickname, profile_img_url } = data;
-      setUserInfo({ id, email, nickname, profile_img_url });
     },
   });
 
@@ -36,6 +31,17 @@ export const useAuthMutate = () => {
     onSuccess: (data) => {
       const { id, nickname, email } = data;
       setUserInfo({ id, email, nickname });
+    },
+  });
+
+  const { mutate: loginUserInfo } = useMutation({
+    mutationFn: async ({ id }) => {
+      const { data } = await supabase.from('users').select('*').eq('id', id).single();
+      return data;
+    },
+    onSuccess: (data) => {
+      const { id, email, nickname, profile_img_url } = data;
+      setUserInfo({ id, email, nickname, profile_img_url });
     },
   });
 

--- a/src/libs/hooks/useAuth.api.js
+++ b/src/libs/hooks/useAuth.api.js
@@ -4,13 +4,11 @@ import useAuthStore from '../../stores/useAuthstore';
 
 export const useAuthMutate = () => {
   const setUserInfo = useAuthStore((state) => state.setUserInfo);
+  const logout = useAuthStore((state) => state.logout);
 
   const { mutate: signUp } = useMutation({
     mutationFn: async ({ email, password }) => {
       const { data, error } = await supabase.auth.signUp({ email, password });
-      console.log('Sign Up Data:', data);
-      console.log('Sign Up Error:', error);
-
       if (error) {
         throw new Error(error.message);
       }
@@ -45,5 +43,14 @@ export const useAuthMutate = () => {
     },
   });
 
-  return { signUp, updateUserInfo, loginUserInfo };
+  const { mutate: logoutUser } = useMutation({
+    mutationFn: async () => {
+      await supabase.auth.signOut();
+    },
+    onSuccess: () => {
+      logout();
+    },
+  });
+
+  return { signUp, updateUserInfo, loginUserInfo, logoutUser };
 };

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../libs/api/supabaseClient';
 import { useState } from 'react';
-import AuthForm from '../components/auth/AuthForm';
+import AuthForm, { LoginButton } from '../components/auth/AuthForm';
 
 const SignIn = () => {
   const navigate = useNavigate();
@@ -41,6 +41,9 @@ const SignIn = () => {
         <h1 className="text-2xl font-extrabold w-full">로그인</h1>
         <AuthForm mode="login" onSubmit={handleSignIn} errorMessage={errorMessage} />
         <div>
+          <LoginButton type="button" color="grey" className={'w-full'}>
+            구글 로그인
+          </LoginButton>
           <p className="mt-7">
             계정이 없으신가요?&nbsp;
             <Link to="/signup" className="text-red-500 font-semibold">

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -35,13 +35,23 @@ const SignIn = () => {
     }
   };
 
+  const handleGoogleLogin = async () => {
+    try {
+      await supabase.auth.signInWithOAuth({
+        provider: 'google',
+      });
+    } catch (err) {
+      throw new Error(err);
+    }
+  };
+
   return (
     <div className="flex items-center justify-center">
       <div className="bg-white shadow-lg rounded-lg p-8 max-w-md w-full">
         <h1 className="text-2xl font-extrabold w-full">로그인</h1>
         <AuthForm mode="login" onSubmit={handleSignIn} errorMessage={errorMessage} />
         <div>
-          <LoginButton type="button" color="grey" className={'w-full'}>
+          <LoginButton type="button" color="grey" className={'w-full'} onClick={handleGoogleLogin}>
             구글 로그인
           </LoginButton>
           <p className="mt-7">

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -8,7 +8,6 @@ const SignIn = () => {
   const [errorMessage, setErrorMessage] = useState('');
 
   const handleSignIn = async (formData) => {
-    // 로그인 로직 구현
     const { email, password } = formData;
 
     // 유효성 검사
@@ -40,8 +39,7 @@ const SignIn = () => {
     <div className="flex items-center justify-center">
       <div className="bg-white shadow-lg rounded-lg p-8 max-w-md w-full">
         <h1 className="text-2xl font-extrabold w-full">로그인</h1>
-        {errorMessage && <p className="text-red-500 mb-4">{errorMessage}</p>}
-        <AuthForm mode="login" onSubmit={handleSignIn} />
+        <AuthForm mode="login" onSubmit={handleSignIn} errorMessage={errorMessage} />
         <div>
           <p className="mt-7">
             계정이 없으신가요?&nbsp;

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,5 +1,4 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { supabase } from '../libs/api/supabaseClient';
 import { useState } from 'react';
 import AuthForm from '../components/auth/AuthForm';
 import { useAuthMutate } from '../libs/hooks/useAuth.api';
@@ -7,7 +6,8 @@ import { useAuthMutate } from '../libs/hooks/useAuth.api';
 const Signup = () => {
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState('');
-  const { updateUserInfo } = useAuthMutate();
+  const { signUp, updateUserInfo } = useAuthMutate();
+
   const handleSignup = async (formData) => {
     const { email, password, passwordRecheck, nickname } = formData;
 
@@ -22,28 +22,13 @@ const Signup = () => {
       return;
     }
 
-    // 회원가입 처리
     try {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-      });
-      if (error) {
-        setErrorMessage(error.message);
-        return;
-      }
+      await signUp({ email, password }); // 회원가입 처리
+      await updateUserInfo({ nickname, email }); // public.users 닉네임 업데이트
       alert('회원가입이 완료되었습니다!');
-    } catch (error) {
-      setErrorMessage('회원가입 중 오류가 발생했습니다.');
-      throw new Error(error);
-    }
-
-    // public.users 테이블 내 nickname 저장
-    try {
-      updateUserInfo({ nickname, email });
       navigate('/signin');
     } catch (error) {
-      setErrorMessage('닉네임 저장 중 오류가 발생했습니다.');
+      setErrorMessage('회원가입 및 닉네임 저장 과정에서 오류가 발생했습니다.');
       throw new Error(error);
     }
   };

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -37,8 +37,7 @@ const Signup = () => {
     <div className="flex items-center justify-center">
       <div className="bg-white shadow-lg rounded-lg p-8 max-w-md w-full">
         <h1 className="text-2xl font-extrabold w-full">회원가입</h1>
-        {errorMessage && <p className="text-red-500 mb-4">{errorMessage}</p>}
-        <AuthForm mode="signup" onSubmit={handleSignup} />
+        <AuthForm mode="signup" onSubmit={handleSignup} errorMessage={errorMessage} />
         <div>
           <p className="mt-7">
             이미 계정이 있으신가요?&nbsp;

--- a/src/stores/useAuthstore.js
+++ b/src/stores/useAuthstore.js
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { persist } from 'zustand/middleware';
 
 const initialState = {
   id: '',
@@ -10,31 +9,24 @@ const initialState = {
 };
 
 const useAuthStore = create(
-  // persist -> userinfo localstorage저장
-  persist(
-    immer((set) => {
-      // immer 삭제ㅋ
-      return {
-        isLogin: false, // 새로고침 시 당연히 false -> persist 쓰기
-        userInfo: initialState,
-        setUserInfo: (userInfo) => {
-          set((state) => {
-            state.userInfo = { ...state.userInfo, ...userInfo };
-            state.isLogin = true;
-          });
-        },
-        logout: () => {
-          set((state) => {
-            state.userInfo = initialState;
-            state.isLogin = false;
-          });
-        },
-      };
-    }),
-    {
-      name: 'gachigagae-auth',
-    }
-  )
+  immer((set) => {
+    return {
+      isLogin: false,
+      userInfo: initialState,
+      setUserInfo: (userInfo) => {
+        set((state) => {
+          state.userInfo = { ...state.userInfo, ...userInfo };
+          state.isLogin = true;
+        });
+      },
+      logout: () => {
+        set((state) => {
+          state.userInfo = initialState;
+          state.isLogin = false;
+        });
+      },
+    };
+  })
 );
 
 export default useAuthStore;


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 로그인 기능 구현

## 📝작업 내용

> 로그아웃 기능 리팩터링 : logoutUser mutation 생성, 기존 Header 안에서 처리하던 비동기 로직을 불러와서 사용하도록 수정했습니다.
> 구글 소셜로그인 기능 추가: 현재 로그인(signIn) 페이지에서 구글 로그인 가능하도록 구현했습니다. 다만 회원가입 하지 않아도 그냥 자동으로 회원가입 처리 + default 닉네임은 null로 가입되도록 처리되고 있습니다.

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/bd06706c-bb38-4e02-a3cc-769c96367862" />
🔼 구글로만 로그인(기존 계정 없음)

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/9b7a51f6-1656-4612-8e50-1cb115f2640c" />
🔼  기존 이메일 가입계정의 구글로그인

기존 로그인했던 이메일이라면, 구글 소셜로그인 시 supabase상 authentication provider에 email, google 2가지가 잘 올라옵니다. 따라서 기존 생성되어있던 계정 정보를 공유하므로, 이전에 설정했던 닉네임과 프로필 이미지는 동일하게 유지됩니다.

## 💬리뷰 요구사항
> 어떤 식으로 개선하면 좋을지 의견 있으시면 자유롭게 남겨주셔요!
> 스크린샷은 지금 맥북이 뻑이났는지 화면기록이 안되어서.. 시연 원하시면 팀스크럼때 진행해볼게요(-.-)(_._)
